### PR TITLE
fix: incorrect controller read-state

### DIFF
--- a/azns_registry/lib.rs
+++ b/azns_registry/lib.rs
@@ -600,6 +600,7 @@ mod azns_registry {
                 }
                 if resolved != owner {
                     address_dict.set_resolved(owner);
+                    self.name_to_address_dict.insert(&name, &address_dict);
 
                     /* Remove the name from the old resolved address */
                     self.remove_name_from_resolving(&resolved, &name);
@@ -632,6 +633,7 @@ mod azns_registry {
                 }
                 if controller != owner {
                     address_dict.set_controller(owner);
+                    self.name_to_address_dict.insert(&name, &address_dict);
 
                     /* Remove the name from the old controller address */
                     self.remove_name_from_controller(&controller, &name);


### PR DESCRIPTION
**Bug:** If controller address of a domain name is different from its owner and owner updates the controller to point to a new address, The name still showed in the reverse-mapping of the formal controller (identified by @wottpal).

**Impact:** The contract shows a user to be in control of names which they don't actually have access to anymore.

**Cause of error:** In the `set_controller`, The removal of a domain name from the reverse-mapping was incorrect. The code tried to remove the name from the `owner` list rather than the `controller` list which is not always the case as controller address can be different from the owner.

**Resolution:** The code was fixed to use address "old_controller" rather than "owner" while removing the name from the reverse-mapping. Also the function `ensure_controller` was renamed to `ensure_controller_owner` to enhance the visibility of access-control in the code
