### PR TITLE
Update token-uri format

### DIFF
--- a/azns_registry/lib.rs
+++ b/azns_registry/lib.rs
@@ -1705,7 +1705,7 @@ mod azns_registry {
             let name: core::result::Result<String, _> = token_id.try_into();
 
             match name {
-                Ok(name) => self.base_uri.clone() + &name + &String::from(".json"),
+                Ok(name) => self.base_uri.clone() + &name + "." + &self.tld + ".json",
                 _ => String::new(),
             }
         }


### PR DESCRIPTION
Closes #106 

old-format: "base_uri/\<name\>.json" (e.g. https://azero.id/api/v1/metadata/alice.json)
new-format: "base_uri/\<name\>.\<tld\>.json" (e.g. https://azero.id/api/v1/metadata/alice.azero.json)